### PR TITLE
LFLT-323 Missing spring.factories in translation adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>hu.psprog.leaflet</groupId>
     <artifactId>leaflet-translation-adapter</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <properties>
 
@@ -26,7 +26,7 @@
         <spring.framework.version>5.1.3.RELEASE</spring.framework.version>
 
         <!-- other versions -->
-        <leaflet.rcp.version>1.3.0</leaflet.rcp.version>
+        <leaflet.rcp.version>1.5.3</leaflet.rcp.version>
         <logback.version>1.2.3</logback.version>
         <slf4j.version>1.7.25</slf4j.version>
         <commons.lang.version>3.8.1</commons.lang.version>
@@ -35,13 +35,14 @@
         <jersey.version>2.27</jersey.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+        <validation-api.version>2.0.1.Final</validation-api.version>
 
         <!-- test framework versions -->
         <junit.version>4.12</junit.version>
         <mockito.version>2.23.4</mockito.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
-        <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
-        <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+        <jacoco-maven-plugin.version>0.8.3</jacoco-maven-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     </properties>
 
@@ -118,6 +119,12 @@
                 <artifactId>javax.annotation-api</artifactId>
                 <version>${javax.annotation-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${validation-api.version}</version>
+                <scope>provided</scope>
+            </dependency>
 
             <!-- test dependencies -->
             <dependency>
@@ -182,6 +189,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
         </dependency>
@@ -225,7 +236,6 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <argLine>${argLine.surefire}</argLine>
-                    <forkCount>0</forkCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/hu/psprog/leaflet/translation/adapter/config/TranslationAdapterConfiguration.java
+++ b/src/main/java/hu/psprog/leaflet/translation/adapter/config/TranslationAdapterConfiguration.java
@@ -1,0 +1,14 @@
+package hu.psprog.leaflet.translation.adapter.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Base configuration for translation adapter.
+ *
+ * @author Peter Smith
+ */
+@Configuration
+@ComponentScan("hu.psprog.leaflet.translation.adapter")
+public class TranslationAdapterConfiguration {
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  hu.psprog.leaflet.translation.adapter.config.TranslationAdapterConfiguration


### PR DESCRIPTION
 - Added Spring configuration class, scanning the adapter package
 - Added spring.factories auto-config descriptor
 - Updated Surefire/JaCoCo version, fixed a module visibility error