### PR TITLE
LFLT-547 Migrate all support library to Java 17 and Spring Boot 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,10 @@
 version: 2.1
 orbs:
-  jira: circleci/jira@1.1.2
+  jira: circleci/jira@1.3.1
 jobs:
   build_leaflet-translation-adapter:
     docker:
-      - image: cimg/openjdk:11.0
+      - image: cimg/openjdk:17.0
     steps:
       - checkout
       - run:

--- a/pom.xml
+++ b/pom.xml
@@ -5,18 +5,18 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>leaflet-translation-adapter</artifactId>
-    <version>2.1.6</version>
+    <version>2.2.0</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>2.1-r2302.1</version>
+        <version>3.0-r2305.1</version>
     </parent>
 
     <properties>
 
         <!-- Java environment version -->
-        <java.version>11</java.version>
+        <java.version>17</java.version>
 
         <!-- compiler settings -->
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/src/main/java/hu/psprog/leaflet/translation/adapter/TMSMessageSource.java
+++ b/src/main/java/hu/psprog/leaflet/translation/adapter/TMSMessageSource.java
@@ -14,7 +14,8 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.support.AbstractMessageSource;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
+
 import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
@@ -25,12 +26,12 @@ import java.util.Set;
  * {@link AbstractMessageSource} implementation to handle TMS based translations.
  * This message source is initialized by calling TMS with a list of translation pack names to retrieve for the application.
  * The list of translation pack names must be provided by the application.
- * After retrieving the available translation packs, every definitions are loaded to the message source.
+ * After retrieving the available translation packs, every definition is loaded to the message source.
  *
  * Configuration must be provided by the integrating application:
- *  - tms.enabled: enables TMS based message source
- *  - tms.packs: name of the packs that the application requests on start-up
- *  - tms.forced-locale: optional, if specified, this will be used as the resolved locale for every request
+ * - tms.enabled: enables TMS based message source
+ * - tms.packs: name of the packs that the application requests on start-up
+ * - tms.forced-locale: optional, if specified, this will be used as the resolved locale for every request
  *
  * @author Peter Smith
  */
@@ -41,10 +42,10 @@ public class TMSMessageSource extends AbstractMessageSource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TMSMessageSource.class);
 
-    private TranslationPackSetToTranslationsConverter translationsConverter;
-    private MessageSourceClient messageSourceClient;
-    private List<String> requiredPacks;
-    private Locale forcedLocale;
+    private final TranslationPackSetToTranslationsConverter translationsConverter;
+    private final MessageSourceClient messageSourceClient;
+    private final List<String> requiredPacks;
+    private final Locale forcedLocale;
     private Translations translations;
 
     @Autowired
@@ -81,6 +82,6 @@ public class TMSMessageSource extends AbstractMessageSource {
 
     private void logRetrievedPacks(Set<TranslationPack> translationPacks) {
         translationPacks.forEach(translationPack -> LOGGER.info("Retrieved translation pack [{}-{} (created at {})]",
-                translationPack.getPackName(), translationPack.getLocale(), translationPack.getCreated()));
+                translationPack.packName(), translationPack.locale(), translationPack.created()));
     }
 }

--- a/src/main/java/hu/psprog/leaflet/translation/adapter/conversion/TranslationPackSetToTranslationsConverter.java
+++ b/src/main/java/hu/psprog/leaflet/translation/adapter/conversion/TranslationPackSetToTranslationsConverter.java
@@ -20,8 +20,8 @@ public class TranslationPackSetToTranslationsConverter implements Converter<Set<
 
         Translations translations = new Translations();
 
-        source.forEach(translationPack -> translationPack.getDefinitions()
-                .forEach(definition -> translations.addTranslation(definition.getKey(), translationPack.getLocale(), definition.getValue())));
+        source.forEach(translationPack -> translationPack.definitions()
+                .forEach(definition -> translations.addTranslation(definition.key(), translationPack.locale(), definition.value())));
 
         return translations;
     }

--- a/src/main/java/hu/psprog/leaflet/translation/adapter/domain/Translations.java
+++ b/src/main/java/hu/psprog/leaflet/translation/adapter/domain/Translations.java
@@ -14,7 +14,7 @@ import java.util.TreeMap;
  */
 public class Translations {
 
-    private Map<String, Map<Locale, String>> translations;
+    private final Map<String, Map<Locale, String>> translations;
 
     public Translations() {
         translations = new TreeMap<>();

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  hu.psprog.leaflet.translation.adapter.config.TranslationAdapterConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+hu.psprog.leaflet.translation.adapter.config.TranslationAdapterConfiguration

--- a/src/test/java/hu/psprog/leaflet/translation/adapter/TMSMessageSourceTest.java
+++ b/src/test/java/hu/psprog/leaflet/translation/adapter/TMSMessageSourceTest.java
@@ -34,7 +34,7 @@ public class TMSMessageSourceTest {
 
     private static final String PACK_NAME = "pack1";
     private static final List<String> PACKS = Collections.singletonList(PACK_NAME);
-    private static final TranslationPack TRANSLATION_PACK = TranslationPack.getPackBuilder()
+    private static final TranslationPack TRANSLATION_PACK = TranslationPack.getBuilder()
             .withPackName(PACK_NAME)
             .withLocale(Locale.ENGLISH)
             .withCreated(new Date())

--- a/src/test/java/hu/psprog/leaflet/translation/adapter/conversion/TranslationPackSetToTranslationsConverterTest.java
+++ b/src/test/java/hu/psprog/leaflet/translation/adapter/conversion/TranslationPackSetToTranslationsConverterTest.java
@@ -46,11 +46,11 @@ public class TranslationPackSetToTranslationsConverterTest {
             .withKey(KEY_2)
             .withValue(VALUE_2_CA)
             .build();
-    private static final TranslationPack TRANSLATION_PACK_1 = TranslationPack.getPackBuilder()
+    private static final TranslationPack TRANSLATION_PACK_1 = TranslationPack.getBuilder()
             .withLocale(Locale.ENGLISH)
             .withDefinitions(Arrays.asList(TRANSLATION_DEFINITION_EN_1, TRANSLATION_DEFINITION_EN_2))
             .build();
-    private static final TranslationPack TRANSLATION_PACK_2 = TranslationPack.getPackBuilder()
+    private static final TranslationPack TRANSLATION_PACK_2 = TranslationPack.getBuilder()
             .withLocale(Locale.CANADA)
             .withDefinitions(Arrays.asList(TRANSLATION_DEFINITION_CA_1, TRANSLATION_DEFINITION_CA_2))
             .build();


### PR DESCRIPTION
 - Minor code improvements and fixing issues caused by the migration
 - Changed stack base BOM version to 3.0-r2305.1
 - Bumped library version to 2.2.0