### PR TITLE
LFLT-637 Update dependencies of Java support libraries and applications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  jira: circleci/jira@2.1.0
-  jq: circleci/jq@3.0.0
+  jira: circleci/jira@2.2.0
+  jq: circleci/jq@3.0.2
 
 executors:
   java:
@@ -24,14 +24,16 @@ workflows:
   build:
     jobs:
       - build_leaflet-translation-adapter:
-         context: leaflet_ci
-         filters:
-           branches:
-             only:
-               - master
-         post-steps:
-           - jira/notify:
-               pipeline_id: << pipeline.id >>
-               pipeline_number: << pipeline.number >>
+          context:
+            - common-tech
+            - github-packages
+          filters:
+            branches:
+              only:
+                - master
+          post-steps:
+            - jira/notify:
+                pipeline_id: << pipeline.id >>
+                pipeline_number: << pipeline.number >>
 
   version: 2

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>leaflet-translation-adapter</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>4.0-r2405.1</version>
+        <version>5.0-r2505.1</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
 - Switched to stack base BOM v5.0-r2505.1
 - CircleCI build plan improvements
 - Bumped library version to 2.3.1