### PR TITLE
LFLT-655 Migrate Java applications to Spring Boot v4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   jira: circleci/jira@2.2.0
-  jq: circleci/jq@3.0.2
 
 executors:
   java:

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>leaflet-translation-adapter</artifactId>
-    <version>2.3.1</version>
+    <version>2.4.0</version>
 
     <parent>
         <groupId>hu.psprog.leaflet</groupId>
         <artifactId>leaflet-stack-base-bom</artifactId>
-        <version>5.0-r2505.1</version>
+        <version>6.0-r2604.2</version>
     </parent>
 
     <properties>
@@ -55,10 +55,6 @@
             <artifactId>logback-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
         </dependency>
@@ -73,8 +69,22 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <proc>full</proc>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -95,7 +105,7 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <!--suppress UnresolvedMavenProperty -->
-                    <argLine>${argLine.surefire}</argLine>
+                    <argLine>${argLine.surefire} -javaagent:"${org.mockito:mockito-core:jar}"</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/hu/psprog/leaflet/translation/adapter/conversion/TranslationPackSetToTranslationsConverterTest.java
+++ b/src/test/java/hu/psprog/leaflet/translation/adapter/conversion/TranslationPackSetToTranslationsConverterTest.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.Locale;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -65,6 +66,7 @@ public class TranslationPackSetToTranslationsConverterTest {
         Translations result = converter.convert(new HashSet<>(Arrays.asList(TRANSLATION_PACK_1, TRANSLATION_PACK_2)));
 
         // then
+        assertThat(result, notNullValue());
         assertThat(result.countTranslations(), equalTo(4L));
         assertThat(result.getTranslation(KEY_1, Locale.CANADA), equalTo(VALUE_1_CA));
         assertThat(result.getTranslation(KEY_1, Locale.ENGLISH), equalTo(VALUE_1_EN));


### PR DESCRIPTION
 - Switched to stack base BOM v6.0-r2604.2
 - POM fixes (annotation processing and Mockito warnings)
 - Bumped library version to 2.4.0